### PR TITLE
\t must be ignored

### DIFF
--- a/libmime-decoders.c
+++ b/libmime-decoders.c
@@ -474,7 +474,9 @@ int MDECODE_decode_ISO( char *isostring, int size )
 				DMD LOGGER_log("%s:%d:MDECODE_decode_ISO:DEBUG: ISO encoding char = '%c'",FL,encoding_type);
 
 				// Get the encoded string
-				token_end = strpbrk(iso,"?;\n\r\t"); //DROPPED THE SPACE here
+                // When unfolding, WSP shuld be ignore. (https://tools.ietf.org/html/rfc5322#section-2.2.3)
+                // WSP =  SP / HTAB ; white space (https://tools.ietf.org/html/rfc5234#appendix-B.1)
+				token_end = strpbrk(iso,"?;\n\r"); //DROPPED THE SPACE and TAB here
 				if (token_end != NULL)
 				{
 					if ((*token_end != '?')&&(*token_end != ';'))


### PR DESCRIPTION
When the filename has some encoding and the base64 is wrapped and there is a (TAB) at the beginning of the line the parsing is broken and rip mime goes into an infinite loop.

```
Content-Type: application/pdf; name="(PDI TX) =?UTF-8?B?4oCTIE1BIC0gRU5MQUNF
    IFNUSS1QSU0g4oCTIDIwMTcgLSBOT1ZPIOKAkyA=?=
 =?UTF-8?B?U0lBRSAtIEFHUzIwIOKAkyBCUi1WSVYwLTE3MDAyNzUg4oCTIFJFViAwMC4=?=
 =?UTF-8?B?cGRm?="
```